### PR TITLE
test: verify SEO auto-merge green-checks gate

### DIFF
--- a/src/content/blog/how-to-build-an-mcp-server.mdx
+++ b/src/content/blog/how-to-build-an-mcp-server.mdx
@@ -210,3 +210,4 @@ Not to start. The five-step server above has none. A database (or any state stor
 Run it under MCP Inspector and call each tool once with real arguments. For a remote server, add the auth check: confirm the gate rejects a request with no token, then connect a real client and call `listTools()` - if the count matches what you registered, the wiring is correct end to end.
 
 Between the five build steps, the transport choice, and the auth pattern, that's most of what separates a demo server from one you'd trust with real tenants - the rest is the tools themselves, which is where DispatchSEO's own agent spends its time.
+


### PR DESCRIPTION
Throwaway end-to-end test of the `seo-auto-merge` workflow after fixing the `SEO_MCP_API_KEY` repo secret (it 401'd on every run since it was set).

The diff is one trailing newline in a blog MDX — deliberately shaped to pass the auto-merge eligibility gate (all files under `src/content/blog/`, label `seo`). If the pipeline is healthy this PR should merge itself once checks report green, with no human involvement. If it's still open an hour from now, something in the gate is broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting in the “How to Build an MCP Server” article by adding spacing between content sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->