### PR TITLE
chore(pipeline): apply DispatchSEO pack update 3ffaaf7d0511

### DIFF
--- a/src/lib/instructions/index.ts
+++ b/src/lib/instructions/index.ts
@@ -12,7 +12,8 @@
 
 import type { Project } from "@/lib/projects";
 import { hasDataforseo } from "@/lib/pipeline-pack";
-import { credsForProject } from "@/lib/dataforseo";
+import { isCloudMode } from "@/lib/cloud";
+import { platformDataforseoEnv } from "@/lib/dataforseo-usage";
 import { getPacing, type Pacing } from "@/lib/pacing";
 import {
   normalizeContentPrefs,
@@ -31,7 +32,7 @@ import { TREND_SCAN, TREND_SCAN_STEPS } from "./trend-scan";
 import { TREND_EXPAND, TREND_EXPAND_STEPS } from "./trend-expand";
 import { GEO_SCAN, GEO_SCAN_STEPS } from "./geo-scan";
 
-export const INSTRUCTIONS_VERSION = "2026-07-24.4";
+export const INSTRUCTIONS_VERSION = "2026-07-24.5";
 
 export const WORKFLOWS = [
   "install",
@@ -130,11 +131,20 @@ export async function renderInstructions(workflow: WorkflowName, project: Projec
   // A bundled-plan cloud project has NO DataForSEO server in its own repo, but
   // the backend still has DataForSEO through the platform account - so the
   // seo-manager MCP's `keyword_ideas` tool serves it real volume/KD (metered
-  // against the project's monthly budget). credsForProject applies the plan +
-  // budget gates: a null here means genuinely no data source right now (free /
-  // GSC-only, or budget spent), which drops to the data-less branch.
-  const platformDataforseo = !dataforseoRepoMcp
-    && (await credsForProject(project))?.billedTo === "platform";
+  // against the project's monthly budget).
+  //
+  // This is a CAPABILITY check (stable), deliberately NOT the live
+  // credsForProject spend gate. Keying the note off credsForProject made a
+  // single transient null - a plan/budget DB read blipping, the monthly budget
+  // momentarily spent, or (as seen in testing) platform env still propagating
+  // mid-deploy - silently flip the ENTIRE run to the data-less branch, so the
+  // agent never called keyword_ideas and the queue came back with no
+  // volume/KD. keyword_ideas itself returns empty-with-note at the cap and the
+  // note already covers that fallback, so the instruction should always tell a
+  // bundled project the tool is there. Pure env + mode reads - no DB, nothing
+  // to blip.
+  const platformDataforseo =
+    !dataforseoRepoMcp && isCloudMode() && platformDataforseoEnv() != null;
   const researchSourceNote = dataforseoRepoMcp
     ? "- This project has its own DataForSEO account wired into the DataForSEO MCP - use it " +
       "(volume, KD, keyword ideas, live SERPs, backlinks endpoints)."


### PR DESCRIPTION
Applies the DispatchSEO SEO-pipeline pack update the dashboard flagged (installed `ba1ef9fd3136` → current `3ffaaf7d0511`; the update notice named `82e88ffd1f1d`, which the backend's "current" advanced past since this morning — installing the freshest pack supersedes it).

## What changed
Refreshed all pack-owned files (`.github/workflows/seo-*.yml`, `.github/mcp-*.json`, `.claude/commands/seo-*.md`, `.dispatchseo/pipeline-version`) from the current pack. Repo-owned config under `.dispatchseo/` (`conventions.md`, `publish-paths`) left untouched; no secrets touched.

### Pack improvements picked up
- `allowed_bots` on the Claude steps (GitHub-App bot-actored scheduled runs)
- **New `seo-setup.yml`** — dispatch-only personalization run
- `seo-research` `repository_dispatch` trigger on weekly-research (first-run queue fill)
- `NEXT_PUBLIC_*` build placeholders; layout-independent guide-slug handling in auto-merge

### Repo-specific adaptations re-applied on top of the generic pack
- **pnpm** — dropped the pack's `version: 11` input in the 3 build workflows; this repo pins pnpm via `packageManager: pnpm@11.5.2`, and version-input + field together hard-error CI.
- **seo-auto-merge** — kept dispatching `publish-images.yml` + `deploy-check.yml` after an auto-merge (GITHUB_TOKEN pushes don't trigger push-event workflows).
- **Backend URL** — accepted the pack's hardcoded `https://dispatchseo.com`; no `BACKEND_URL` repo variable is set, so behavior is identical to the prior `vars.BACKEND_URL` fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)