### PR TITLE
feat(discord): every release announces itself in the Discord server

### DIFF
--- a/.github/workflows/changelog-announce.yml
+++ b/.github/workflows/changelog-announce.yml
@@ -1,0 +1,141 @@
+name: Announce changelog to Discord
+
+# Posts every new release to the Discord server, automatically, the moment it
+# goes live. The source is src/lib/changelog.ts - the same list the dashboard
+# banner, /changelog and the get_changelog MCP tool read - so shipping a
+# release is still one edit to one file, and Discord follows.
+#
+# Only a NEW version announces. The path filter decides whether this workflow
+# runs at all; scripts/announce-changelog.mjs then diffs versions against the
+# state of the file before this push, so typo fixes, rewordings and edits to
+# the helpers below the array all run and post nothing. It waits for the
+# release to actually be serving on /changelog before posting, because the
+# embed deep-links to it.
+#
+# Setup (once): create a webhook in Discord (Server Settings -> Integrations
+# -> Webhooks -> New Webhook, pick the channel, Copy Webhook URL) and save it
+# as the repository secret DISCORD_WEBHOOK_URL. The webhook's own name and
+# avatar in Discord are what the posts appear as. Optional repository variable
+# DISCORD_MENTION (e.g. `<@&123456789>`) pings a role above each embed.
+#
+# Test it without shipping anything: run this workflow manually with a version
+# input and dry run left on - it prints the exact payload to the run log.
+#
+# Known edge: re-running this workflow after a partial failure re-posts what it
+# already posted. Deleting a duplicate in Discord is a two-second fix; the
+# alternative (a bot token to read channel history) is not worth it here.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/lib/changelog.ts"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Announce this exact version (e.g. 2026-07-30.8), instead of diffing for new ones"
+        required: false
+      dry_run:
+        description: "Print the Discord payload instead of posting it"
+        type: boolean
+        default: true
+
+concurrency:
+  group: changelog-announce
+  cancel-in-progress: false # never cancel mid-post - a half-posted release is worse than a slow one
+
+jobs:
+  announce:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # need the pre-push commit to diff versions against
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Fail early if the webhook secret is missing
+        id: guard
+        if: ${{ !inputs.dry_run }}
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+          URL: ${{ vars.BACKEND_URL || 'https://dispatchseo.com' }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then
+            msg="DISCORD_WEBHOOK_URL is not set - releases are shipping but nothing is reaching Discord. Add it under repo Settings -> Secrets -> Actions (get the URL from Discord: Server Settings -> Integrations -> Webhooks)"
+            echo "::error::$msg"
+            curl -sG --max-time 30 -H "Authorization: Bearer $CRON_SECRET" \
+              --data-urlencode "job=changelog-announce" \
+              --data-urlencode "fail=$msg" \
+              "$URL/api/cron/deploy-check" || true
+            exit 1
+          fi
+
+      - name: Take the pre-push copy of the changelog
+        id: baseline
+        env:
+          BEFORE: ${{ github.event.before }}
+        run: |
+          # github.event.before is the tip of main BEFORE this push, so a push
+          # carrying several commits is still diffed against the right state
+          # (HEAD^ would only look one commit back). Empty on manual runs, and
+          # all-zeros on a brand new branch - both fall back to HEAD^.
+          prev="$BEFORE"
+          case "$prev" in "" | 0000000000000000000000000000000000000000) prev="HEAD^" ;; esac
+          out="$RUNNER_TEMP/prev-changelog.ts"
+          if git show "$prev:src/lib/changelog.ts" > "$out" 2>/dev/null; then
+            echo "Diffing against $prev"
+            echo "path=$out" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::No pre-push copy of the changelog available - only the newest entry is eligible."
+          fi
+
+      - name: Announce
+        id: announce
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_MENTION: ${{ vars.DISCORD_MENTION }}
+          SITE_URL: ${{ vars.BACKEND_URL || 'https://dispatchseo.com' }}
+          # Through env, never interpolated into the shell: `version` is
+          # attacker-controlled in the general case (anyone who can dispatch a
+          # workflow), and a quoted expansion can't become part of the command.
+          BASELINE: ${{ steps.baseline.outputs.path }}
+          FORCED_VERSION: ${{ inputs.version }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          args=()
+          if [ -n "$BASELINE" ]; then args+=(--previous "$BASELINE"); fi
+          if [ -n "$FORCED_VERSION" ]; then args+=(--version "$FORCED_VERSION"); fi
+          if [ "$DRY_RUN" = "true" ]; then args+=(--dry-run); fi
+          node --experimental-strip-types scripts/announce-changelog.mjs "${args[@]}"
+
+      # Same rails as the crons: a failure here lands on the dashboard Home
+      # banner and the alert email, so a webhook that quietly stopped working
+      # is noticed at the next release instead of never. No STALE_HOURS entry
+      # in cron-alerts.ts on purpose - this is release-driven, not scheduled,
+      # and a quiet fortnight is a normal state, not an alarm.
+      # Excluded only when the guard step already reported the missing-secret
+      # failure itself - anything else that goes wrong, including a step that
+      # dies before Announce ever runs, still has to phone home.
+      - name: Report outcome to the dashboard
+        if: always() && steps.guard.outcome != 'failure' && !inputs.dry_run
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+          URL: ${{ vars.BACKEND_URL || 'https://dispatchseo.com' }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          OUTCOME: ${{ job.status }}
+        run: |
+          if [ "$OUTCOME" = "success" ]; then
+            curl -sG --max-time 30 -H "Authorization: Bearer $CRON_SECRET" \
+              --data-urlencode "job=changelog-announce" --data-urlencode "ok=1" \
+              "$URL/api/cron/deploy-check" || true
+          else
+            curl -sG --max-time 30 -H "Authorization: Bearer $CRON_SECRET" \
+              --data-urlencode "job=changelog-announce" \
+              --data-urlencode "fail=the release did not reach Discord - $RUN_URL" \
+              "$URL/api/cron/deploy-check" || true
+          fi

--- a/scripts/announce-changelog.mjs
+++ b/scripts/announce-changelog.mjs
@@ -1,0 +1,318 @@
+#!/usr/bin/env node
+// Announces new changelog releases to Discord, straight from the one list that
+// already defines them - src/lib/changelog.ts. The dashboard banner, the
+// /changelog page, the get_changelog MCP tool and now the Discord server all
+// read that same array, so a release is still written exactly once, in the
+// owner's language, and never re-typed for an audience.
+//
+// What counts as "new" is decided by diffing versions against a previous copy
+// of the file (the workflow hands over `git show HEAD^:src/lib/changelog.ts`),
+// NOT by "the file changed" - fixing a typo in an old entry, reordering, or
+// touching the helpers below the array must never re-announce anything. With
+// no previous copy to compare against, only the head entry is eligible, so a
+// first run can't dump 25 historical releases into the channel.
+//
+// It waits for the release to actually be live on /changelog before posting,
+// because the embed links to `#v-<version>` - announcing a release the site
+// isn't serving yet is a dead link in a permanent, public channel.
+//
+//   node scripts/announce-changelog.mjs --previous /tmp/prev-changelog.ts
+//   node scripts/announce-changelog.mjs --version 2026-07-30.8 --dry-run
+//
+// Env: DISCORD_WEBHOOK_URL (required unless --dry-run), SITE_URL
+// (default https://dispatchseo.com), DISCORD_MENTION (optional, e.g. a role
+// ping like `<@&123>` posted as the message content above the embed).
+
+import { existsSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+// ---------------------------------------------------------------- arguments
+
+const argv = process.argv.slice(2);
+const flag = (name) => argv.includes(`--${name}`);
+const opt = (name) => {
+  const i = argv.indexOf(`--${name}`);
+  return i >= 0 ? argv[i + 1] : undefined;
+};
+
+const dryRun = flag("dry-run");
+const noWait = flag("no-wait") || dryRun;
+const previousPath = opt("previous");
+const forcedVersion = opt("version");
+const webhook = process.env.DISCORD_WEBHOOK_URL?.trim();
+const site = (process.env.SITE_URL?.trim() || "https://dispatchseo.com").replace(/\/+$/, "");
+const mention = process.env.DISCORD_MENTION?.trim() || "";
+
+// A release announcement is public and permanent. Cap how much one run can
+// ever say, so a bad diff (a rewritten file, a squashed branch) posts a few
+// messages someone can delete rather than flooding the channel.
+const MAX_POSTS = 5;
+
+// Discord's own limits, minus a little headroom.
+const BULLET_MAX = 500; // per change line, before "…"
+const FIELD_MAX = 1024; // hard Discord limit on a field value
+const DESC_MAX = 1200; // hard limit is 4096; summaries are 2-3 sentences
+const EMBED_BUDGET = 5500; // hard limit is 6000 across the whole embed
+
+const KIND = {
+  new: { label: "✨ Added", color: 0x34d399 }, // emerald-400, as on /changelog
+  improved: { label: "⚡ Improved", color: 0x38bdf8 }, // sky-400
+  fixed: { label: "🔧 Fixed", color: 0xa3a3a3 }, // neutral-400
+};
+const KIND_ORDER = ["new", "improved", "fixed"];
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function die(msg) {
+  console.error(`announce-changelog: ${msg}`);
+  process.exit(1);
+}
+
+// ------------------------------------------------------- reading the source
+
+// changelog.ts is pure data with no imports, so Node's type stripping can load
+// it directly - no build step, no second copy of the content to drift.
+async function loadChangelog(path) {
+  const mod = await import(pathToFileURL(resolve(path)).href);
+  if (!Array.isArray(mod.CHANGELOG)) throw new Error(`${path} exports no CHANGELOG array`);
+  return mod;
+}
+
+const current = await loadChangelog(join(root, "src", "lib", "changelog.ts"));
+const { CHANGELOG, anchorFor } = current;
+if (!CHANGELOG.length) die("CHANGELOG is empty - nothing to announce");
+
+/** The releases this run should post, oldest first (so the newest lands last). */
+async function selectEntries() {
+  if (forcedVersion) {
+    const entry = CHANGELOG.find((e) => e.version === forcedVersion);
+    if (!entry) die(`no changelog entry with version "${forcedVersion}"`);
+    return [entry];
+  }
+
+  if (!previousPath || !existsSync(previousPath)) {
+    // No baseline: the head entry is the only thing that can honestly be
+    // called "new". Everything older is already out in the world.
+    console.log("No previous changelog to diff against - considering the head entry only.");
+    return [CHANGELOG[0]];
+  }
+
+  const previous = await loadChangelog(previousPath);
+  const known = new Set(previous.CHANGELOG.map((e) => e.version));
+  const fresh = CHANGELOG.filter((e) => !known.has(e.version)).reverse();
+  if (fresh.length > MAX_POSTS) {
+    const dropped = fresh.length - MAX_POSTS;
+    console.log(
+      `${fresh.length} new releases in one push - posting the newest ${MAX_POSTS}, skipping ${dropped} older one(s).`,
+    );
+    return fresh.slice(-MAX_POSTS);
+  }
+  return fresh;
+}
+
+// -------------------------------------------------------- building the post
+
+function clamp(text, max) {
+  const s = text.replace(/\s+/g, " ").trim();
+  if (s.length <= max) return s;
+  const cut = s.slice(0, max - 1);
+  const space = cut.lastIndexOf(" ");
+  return `${(space > max * 0.6 ? cut.slice(0, space) : cut).trimEnd()}…`;
+}
+
+/** One kind's bullets, split across as many fields as Discord's 1024 needs. */
+function packFields(label, items) {
+  const fields = [];
+  let buf = [];
+  const flush = () => {
+    if (!buf.length) return;
+    fields.push({ name: fields.length ? `${label} (cont.)` : label, value: buf.join("\n\n") });
+    buf = [];
+  };
+  for (const item of items) {
+    const projected = buf.length ? buf.join("\n\n").length + 2 + item.length : item.length;
+    if (projected > FIELD_MAX) flush();
+    buf.push(item);
+  }
+  flush();
+  return fields;
+}
+
+function buildEmbed(entry) {
+  const url = `${site}/changelog#${anchorFor(entry.version)}`;
+  const kinds = new Set(entry.changes.map((c) => c.kind));
+  // One colour per release, picked the way the site picks it: the most
+  // significant kind present wins, so a fix-only release reads quieter.
+  const color = KIND[KIND_ORDER.find((k) => kinds.has(k)) ?? "fixed"].color;
+
+  const title = clamp(entry.title, 240);
+  const description = clamp(entry.summary, DESC_MAX);
+  let spent = title.length + description.length + 80; // + footer, roughly
+
+  // Every field, tagged with where it belongs in the embed (`order`) and how
+  // much it deserves to survive a squeeze (`rank`). A kind's FIRST field
+  // outranks every continuation field, so an overlong release still shows
+  // something under each of Added / Improved / Fixed rather than spending the
+  // whole budget on Added and silently dropping the other two.
+  const wanted = [];
+  KIND_ORDER.forEach((kind, group) => {
+    const items = entry.changes
+      .filter((c) => c.kind === kind)
+      .map((c) => `• ${clamp(c.text, BULLET_MAX)}`);
+    packFields(KIND[kind].label, items).forEach((field, i) => {
+      wanted.push({ ...field, group, order: wanted.length, rank: i === 0 ? 0 : 1 + i });
+    });
+  });
+
+  const kept = [];
+  const truncatedGroups = new Set();
+  let dropped = 0;
+  for (const field of [...wanted].sort((a, b) => a.rank - b.rank || a.order - b.order)) {
+    const cost = field.name.length + field.value.length;
+    // Once a group loses a continuation field, drop the rest of that group
+    // too - a gap in the middle of one list reads as scrambled, where a clean
+    // "there's more" tail reads as trimmed.
+    if (truncatedGroups.has(field.group) || kept.length >= 24 || spent + cost > EMBED_BUDGET) {
+      truncatedGroups.add(field.group);
+      dropped++;
+      continue;
+    }
+    kept.push(field);
+    spent += cost;
+  }
+
+  const fields = kept
+    .sort((a, b) => a.order - b.order)
+    .map(({ name, value }) => ({ name, value }));
+  if (dropped) {
+    fields.push({
+      name: "​",
+      value: `[There's more in the full release notes →](${url})`,
+    });
+  }
+
+  return {
+    title,
+    url,
+    description,
+    color,
+    fields,
+    footer: { text: `DispatchSEO · ${entry.version}` },
+    timestamp: new Date(`${entry.date}T12:00:00Z`).toISOString(),
+  };
+}
+
+// ------------------------------------------------------------ waiting + posting
+
+/** Don't link to a release the site isn't serving yet. */
+async function waitForLive(versions) {
+  const url = `${site}/changelog`;
+  const deadline = Date.now() + 10 * 60 * 1000;
+  let lastNote = "";
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url, {
+        headers: { "cache-control": "no-cache" },
+        signal: AbortSignal.timeout(30_000),
+      });
+      if (res.ok) {
+        const html = await res.text();
+        const missing = versions.filter((v) => !html.includes(anchorFor(v)));
+        if (!missing.length) {
+          console.log(`${url} is serving ${versions.join(", ")}.`);
+          return;
+        }
+        lastNote = `waiting for ${missing.join(", ")} to go live`;
+      } else {
+        lastNote = `${url} returned HTTP ${res.status}`;
+      }
+    } catch (e) {
+      lastNote = `${url} unreachable (${e instanceof Error ? e.message : String(e)})`;
+    }
+    console.log(`${lastNote} - retrying in 15s`);
+    await sleep(15_000);
+  }
+  die(
+    `gave up after 10 minutes: ${lastNote}. The deploy carrying this release probably failed - ` +
+      `nothing was announced, so re-run this workflow once the site is serving it.`,
+  );
+}
+
+async function post(payload) {
+  const endpoint = new URL(webhook);
+  endpoint.searchParams.set("wait", "true"); // make Discord answer with the message, not a bare 204
+  for (let attempt = 1; attempt <= 5; attempt++) {
+    let res;
+    try {
+      res = await fetch(endpoint, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload),
+        signal: AbortSignal.timeout(30_000),
+      });
+    } catch (e) {
+      if (attempt === 5) throw e;
+      await sleep(2000 * attempt);
+      continue;
+    }
+    if (res.ok) return;
+    const body = await res.text().catch(() => "");
+    if (res.status === 429) {
+      let wait = 5000;
+      try {
+        wait = Math.ceil((JSON.parse(body).retry_after ?? 5) * 1000);
+      } catch {
+        /* keep the default */
+      }
+      console.log(`Rate-limited by Discord, waiting ${wait}ms`);
+      await sleep(Math.min(wait + 500, 60_000));
+      continue;
+    }
+    if (res.status >= 500) {
+      if (attempt === 5) throw new Error(`Discord is failing: HTTP ${res.status} ${body}`);
+      await sleep(2000 * attempt);
+      continue;
+    }
+    // 401/404 means the webhook URL is wrong or was deleted in Discord;
+    // 400 means the embed itself is malformed. Neither is worth retrying.
+    throw new Error(
+      `Discord rejected the post: HTTP ${res.status} ${body.slice(0, 300)}` +
+        (res.status === 401 || res.status === 404
+          ? " - the DISCORD_WEBHOOK_URL secret is wrong or the webhook was deleted in Discord"
+          : ""),
+    );
+  }
+  throw new Error("Discord rate-limited five attempts in a row - nothing was posted");
+}
+
+// ------------------------------------------------------------------- run it
+
+const entries = await selectEntries();
+if (!entries.length) {
+  console.log("No new release in this change - nothing to announce.");
+  process.exit(0);
+}
+console.log(`Announcing: ${entries.map((e) => e.version).join(", ")}`);
+
+if (!webhook && !dryRun) {
+  die("DISCORD_WEBHOOK_URL is not set - add it as a repository secret (Discord: Server Settings → Integrations → Webhooks)");
+}
+
+if (!noWait) await waitForLive(entries.map((e) => e.version));
+
+for (const [i, entry] of entries.entries()) {
+  const payload = { embeds: [buildEmbed(entry)] };
+  if (mention) payload.content = mention;
+  if (dryRun) {
+    console.log(JSON.stringify(payload, null, 2));
+    continue;
+  }
+  await post(payload);
+  console.log(`Posted ${entry.version} - "${entry.title}"`);
+  if (i < entries.length - 1) await sleep(1500); // stay well under the webhook rate limit
+}
+
+console.log(dryRun ? "Dry run - nothing was posted." : `Done: ${entries.length} announced.`);


### PR DESCRIPTION
Pushing a new entry to `src/lib/changelog.ts` now posts it to the Discord server. The release is still written once, in the owner's language, in the one list the dashboard banner, `/changelog` and `get_changelog` already read — Discord just becomes a fourth reader.

## How it decides to post

**New `version` only.** The path filter decides whether the workflow runs; the script then diffs versions against the changelog as it stood before the push (`github.event.before`, so a multi-commit push is compared against the right state). Typo fixes, reworded summaries and edits to the helpers below the array all run the workflow and post nothing.

**It waits for the release to be live** on `/changelog` before posting, because the embed deep-links to `#v-<version>`. If the deploy never lands, it fails rather than publishing a dead link into a permanent public channel.

**One embed per release**, changes grouped under ✨ Added / ⚡ Improved / 🔧 Fixed in the same emerald/sky/neutral the changelog page uses, one colour per release picked by the most significant kind present.

## Limits and failure modes

Fields are packed to stay inside Discord's 1024-per-field and 6000-per-embed limits, and each kind is guaranteed its first field before any kind gets a second — so an overlong release can't spend the whole budget on Added and silently drop Improved and Fixed. A run can post at most 5 messages and logs what it skipped.

Outcomes report under `job=changelog-announce`, so a webhook that quietly stopped working reaches the Home banner and the alert email at the next release. Deliberately **no** `STALE_HOURS` entry in `cron-alerts.ts`: this is release-driven, so a quiet fortnight is a normal state, not an alarm.

Known edge, documented in the workflow: re-running after a partial failure re-posts what it already posted. Deleting a duplicate in Discord is a two-second fix; a bot token to read channel history is not worth it here.

## Testing

- Real history: no baseline → head entry only; current file as baseline → nothing to announce; a 6-commits-back baseline → the 4 releases since, oldest first; full history → the 5-post cap engaging and naming what it skipped. Bad `--version` exits 1.
- Synthetic worst case (300-char title, 3000-char summary, 20 paragraph-length changes): every field ≤1024, total 4568/6000, all three kinds represented, overflow replaced by a link to the full notes.
- No `${{ }}` interpolation inside any `run:` block.

## Setup

One repository secret, `DISCORD_WEBHOOK_URL` (Discord: Server Settings → Integrations → Webhooks). Optional repository variable `DISCORD_MENTION` to ping a role. Manual dispatch takes a `version` input and defaults dry run **on**, which prints the payload to the run log instead of posting.

No changelog entry (internal-only) and no MCP tool: this adds no state surface, so the parity rule doesn't apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated Discord announcements for newly published changelog entries.
  * Release announcements include formatted summaries, bullet points, and links to full release notes.
  * Added support for previewing announcements before posting and manually announcing a specific release.
  * Added safeguards and retry handling for missing configuration, rate limits, and posting failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->