### PR TITLE
feat(self-host): Coolify deploy template and docs guide

### DIFF
--- a/docker/coolify/docker-compose.yml
+++ b/docker/coolify/docker-compose.yml
@@ -1,8 +1,15 @@
 # DispatchSEO on Coolify - the same stack as the root docker-compose.yml,
 # reshaped for a platform that owns TLS, domains, and secrets. This file is
-# Coolify-only: it uses Coolify compose extensions (exclude_from_hc, magic
-# SERVICE_* variables) that plain `docker compose` rejects - on your own
-# machine or a bare VPS, use the root docker-compose.yml via start.sh.
+# Coolify-only: the magic SERVICE_* variables below only resolve there - on
+# your own machine or a bare VPS, use the root docker-compose.yml via
+# start.sh.
+#
+# Everything else in this file is STANDARD compose schema on purpose:
+# Coolify validates the file with `docker compose config` before its own
+# parsing, and that validator rejects even Coolify's own documented
+# extensions (exclude_from_hc, content:, is_directory: - see
+# coollabsio/coolify#5494), so none of them may appear here or the resource
+# fails with "invalid format" at creation.
 #
 # Point a Coolify "Public Repository" resource at this repo with:
 #
@@ -64,13 +71,13 @@ services:
 
   # One-shot on every deploy: applies supabase/migrations/setup.sql
   # (idempotent - it is how upgrades pick up new tables), then tells a
-  # running PostgREST to reload its schema cache. exclude_from_hc keeps the
-  # normally-exited one-shot from marking the whole stack unhealthy in
-  # Coolify's eyes.
+  # running PostgREST to reload its schema cache. It exits 0 when done, so
+  # Coolify lists it as "Exited" - that is this container working as
+  # designed, not a failure. (Coolify's exclude_from_hc flag exists for
+  # exactly this, but its validator rejects it - see the header.)
   migrate:
     image: postgres:17-alpine
     restart: "no"
-    exclude_from_hc: true
     environment:
       - PGHOST=postgres
       - PGUSER=dispatch

--- a/docker/coolify/docker-compose.yml
+++ b/docker/coolify/docker-compose.yml
@@ -1,0 +1,191 @@
+# DispatchSEO on Coolify - the same stack as the root docker-compose.yml,
+# reshaped for a platform that owns TLS, domains, and secrets. This file is
+# Coolify-only: it uses Coolify compose extensions (exclude_from_hc, magic
+# SERVICE_* variables) that plain `docker compose` rejects - on your own
+# machine or a bare VPS, use the root docker-compose.yml via start.sh.
+#
+# Point a Coolify "Public Repository" resource at this repo with:
+#
+#   Build Pack:              Docker Compose
+#   Base Directory:          /
+#   Docker Compose Location: /docker/coolify/docker-compose.yml
+#
+# then enable Configuration > General > "Preserve Repository During
+# Deployment". The migrate and cron services bind-mount files out of this
+# repo at deploy time; without that setting Coolify deploys from a directory
+# where those files do not exist and creates empty DIRECTORIES at their
+# paths instead (coollabsio/coolify#6056), which kills the schema install.
+#
+# Bind-mount paths below are written relative to the Base Directory (the
+# repo root), NOT relative to this file - that is how Coolify resolves them
+# in compose deployments, so do not "fix" them to ../../.
+#
+# Walkthrough: https://dispatchseo.com/docs/coolify
+#
+# Differences from the root compose file, all deliberate:
+#   - No caddy service and no published ports. Coolify's own proxy
+#     terminates HTTPS and routes the assigned domain to the app container
+#     (the SERVICE_FQDN_APP_3000 line); a host port would only bypass it.
+#   - No `build:` on app/builder. Coolify builds every service that carries
+#     one, and a Next.js production build wants more RAM than many Coolify
+#     boxes have spare - the prebuilt GHCR images track this repo's main
+#     branch instead. Forks that changed code should restore `build: .` on
+#     app and `build: ./docker/builder` on builder.
+#   - Secrets are Coolify magic variables (SERVICE_PASSWORD_*): generated on
+#     the first deploy, stable across redeploys, visible in the resource's
+#     Environment Variables tab. Nothing to fill in by hand.
+#   - No `name:` / `networks:`. Coolify names the stack per resource and
+#     puts its services on their own isolated network, so pinning either
+#     here would fight the platform (and break running two installs on one
+#     server).
+#
+# PERSISTENCE: everything lives in the two named volumes at the bottom -
+# dispatch-pgdata IS the database. They survive redeploys and image
+# upgrades, but Coolify's "Delete Resource" removes them with the stack, so
+# back up first: https://dispatchseo.com/docs/upgrading
+
+services:
+  postgres:
+    image: postgres:17-alpine
+    restart: always
+    environment:
+      - POSTGRES_USER=dispatch
+      - POSTGRES_PASSWORD=${SERVICE_PASSWORD_POSTGRES}
+      - POSTGRES_DB=dispatchseo
+    volumes:
+      - dispatch-pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - pg_isready -U dispatch -d dispatchseo
+      interval: 10s
+      timeout: 3s
+      retries: 5
+
+  # One-shot on every deploy: applies supabase/migrations/setup.sql
+  # (idempotent - it is how upgrades pick up new tables), then tells a
+  # running PostgREST to reload its schema cache. exclude_from_hc keeps the
+  # normally-exited one-shot from marking the whole stack unhealthy in
+  # Coolify's eyes.
+  migrate:
+    image: postgres:17-alpine
+    restart: "no"
+    exclude_from_hc: true
+    environment:
+      - PGHOST=postgres
+      - PGUSER=dispatch
+      - PGPASSWORD=${SERVICE_PASSWORD_POSTGRES}
+      - PGDATABASE=dispatchseo
+    volumes:
+      - ./supabase/migrations/setup.sql:/setup.sql:ro
+    command:
+      - sh
+      - -c
+      - psql -v ON_ERROR_STOP=1 -f /setup.sql && psql -c "NOTIFY pgrst, 'reload schema'"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  postgrest:
+    image: postgrest/postgrest:v12.2.12
+    restart: always
+    environment:
+      - PGRST_DB_URI=postgres://dispatch:${SERVICE_PASSWORD_POSTGRES}@postgres:5432/dispatchseo
+      - PGRST_DB_SCHEMAS=public
+      - PGRST_DB_ANON_ROLE=dispatch
+      - PGRST_DB_POOL=10
+    depends_on:
+      postgres:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+
+  app:
+    image: ghcr.io/neozi12/dispatchseo:latest
+    restart: always
+    environment:
+      # Coolify magic: give this service a domain and route it to container
+      # port 3000. Coolify generates one under your wildcard domain on the
+      # first deploy; set your real subdomain in the service's Domains field
+      # and APP_URL follows it on the next deploy.
+      - SERVICE_FQDN_APP_3000
+      - APP_URL=${SERVICE_URL_APP_3000}
+      - POSTGREST_URL=http://postgrest:3000
+      - CRON_SECRET=${SERVICE_PASSWORD_CRON}
+      # Optional overrides - the setup wizard handles all of these in the
+      # dashboard; set one (Environment Variables tab) only to force a
+      # value. The list must stay in sync with the root compose file: this
+      # service enumerates its env explicitly, so a variable not listed here
+      # never reaches the app.
+      - DASHBOARD_PASSWORD=${DASHBOARD_PASSWORD:-}
+      - MCP_API_KEY=${MCP_API_KEY:-}
+      - GSC_SERVICE_ACCOUNT_JSON=${GSC_SERVICE_ACCOUNT_JSON:-}
+      - GSC_SITE_URL=${GSC_SITE_URL:-}
+      - DATAFORSEO_LOGIN=${DATAFORSEO_LOGIN:-}
+      - DATAFORSEO_PASSWORD=${DATAFORSEO_PASSWORD:-}
+      - GH_MERGE_TOKEN=${GH_MERGE_TOKEN:-}
+      # Builder credentials on the APP as well as the builder - the app is
+      # what resolves a token per job and hands it to the container (the
+      # root compose file documents the silent-stall failure mode when these
+      # two lists diverge).
+      - CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN:-}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - CURSOR_API_KEY=${CURSOR_API_KEY:-}
+      - RESEND_API_KEY=${RESEND_API_KEY:-}
+      - ALERT_EMAIL=${ALERT_EMAIL:-}
+      - ALERT_EMAIL_FROM=${ALERT_EMAIL_FROM:-}
+      - SEED_KEYWORDS=${SEED_KEYWORDS:-}
+      # The anonymous once-a-day install ping (src/lib/heartbeat.ts). No
+      # start.sh runs here to write an install id into .env; the app
+      # generates one and stores it in its own database instead. Set
+      # DISPATCHSEO_TELEMETRY=off to stop the ping.
+      - DISPATCH_INSTALL_ID=${DISPATCH_INSTALL_ID:-}
+      - DISPATCHSEO_TELEMETRY=${DISPATCHSEO_TELEMETRY:-}
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+      postgrest:
+        condition: service_started
+
+  cron:
+    image: alpine:3.21
+    restart: always
+    environment:
+      - CRON_SECRET=${SERVICE_PASSWORD_CRON}
+      - APP_INTERNAL_URL=http://app:3000
+    volumes:
+      - ./docker/cron/crontab:/etc/crontabs/root:ro
+      - ./docker/cron/hit.sh:/usr/local/bin/hit.sh:ro
+      - ./docker/cron/entrypoint.sh:/entrypoint.sh:ro
+    entrypoint:
+      - /bin/sh
+      - /entrypoint.sh
+    depends_on:
+      app:
+        condition: service_started
+
+  builder:
+    image: ghcr.io/neozi12/dispatchseo-builder:latest
+    restart: always
+    environment:
+      - CRON_SECRET=${SERVICE_PASSWORD_CRON}
+      - APP_INTERNAL_URL=http://app:3000
+      # All optional - the easiest path is pasting the agent token on the
+      # dashboard's "Turn on automatic builds" step; a value set here
+      # overrides the dashboard one.
+      - CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN:-}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - CURSOR_API_KEY=${CURSOR_API_KEY:-}
+      - CODEX_MODEL=${CODEX_MODEL:-}
+      - CURSOR_MODEL=${CURSOR_MODEL:-}
+      - BUILDER_GH_TOKEN=${BUILDER_GH_TOKEN:-}
+      - BUILDER_POLL_SECONDS=${BUILDER_POLL_SECONDS:-600}
+    volumes:
+      - dispatch-builder:/data
+    depends_on:
+      app:
+        condition: service_started
+
+volumes:
+  dispatch-pgdata:
+  dispatch-builder:

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -42,6 +42,10 @@ automatic HTTPS - this block is the plain version that works anywhere.)
   installs everything (Docker included), then one DNS record + one .env
   line puts the dashboard on your subdomain with automatic HTTPS. This is
   the path we recommend once you're past trying it out.
+- **[Install on Coolify](https://dispatchseo.com/docs/coolify)** - already
+  running Coolify? Deploy the ready-made template
+  (`docker/coolify/docker-compose.yml`) from its UI: generated secrets,
+  your domain with HTTPS, no SSH.
 - **[The setup wizard, step by step](https://dispatchseo.com/docs/setup-wizard)** -
   what each screen asks for and why: your site, the Search Console service
   account, keyword data (free mode vs DataForSEO), publish mode, one-tap

--- a/src/content/docs/coolify.mdx
+++ b/src/content/docs/coolify.mdx
@@ -62,6 +62,10 @@ optional overrides (`DASHBOARD_PASSWORD`, Search Console JSON, DataForSEO
 keys, ...), but every one of them is collected by the setup wizard in the
 browser, which stores them in the database. Leave them empty.
 
+One thing that looks wrong but isn't: once the deploy settles, the
+`migrate` service shows as **Exited**. It's a one-shot - it installs the
+schema and quits, on purpose, on every deploy.
+
 When the deploy finishes, the `app` service has a generated URL under your
 Coolify wildcard domain - click it and the dashboard loads over HTTPS.
 

--- a/src/content/docs/coolify.mdx
+++ b/src/content/docs/coolify.mdx
@@ -1,0 +1,116 @@
+---
+title: Install on Coolify
+description: Deploy the whole stack from Coolify's UI - a ready-made compose template, auto-generated secrets, and your domain with HTTPS, no SSH required.
+---
+
+[Coolify](https://coolify.io) is an open-source, self-hostable platform that
+deploys apps from a Git repo through a web UI. If your server already runs
+it, this is the easiest install: DispatchSEO ships a ready-made template at
+`docker/coolify/docker-compose.yml`, Coolify generates the secrets, and its
+proxy puts the dashboard on your domain with HTTPS. No SSH, no `.env`.
+
+If you don't run Coolify, don't install it just for this - [the VPS
+guide](/docs/vps) gets you the same stack with one command.
+
+<Steps>
+
+<Step title="Create the resource">
+
+In Coolify, open a project and **Add New Resource → Public Repository**.
+Fill it in like this:
+
+<Fields>
+  <Field name="Repository URL">`https://github.com/NeoZi12/dispatchseo`</Field>
+  <Field name="Branch">`main`</Field>
+  <Field name="Build Pack">**Docker Compose**</Field>
+  <Field name="Base Directory">`/` (the default)</Field>
+  <Field name="Docker Compose Location">`/docker/coolify/docker-compose.yml`</Field>
+</Fields>
+
+That last field is the one to get right: it points Coolify at the
+Coolify-specific template instead of the root compose file, which is written
+for machines where Docker is all there is.
+
+Continue, and Coolify parses the file and shows the stack: `postgres`,
+`migrate`, `postgrest`, `app`, `cron`, and `builder`.
+
+</Step>
+
+<Step title="Turn on Preserve Repository During Deployment">
+
+Before deploying, open the resource's **Configuration → General** and enable
+**Preserve Repository During Deployment**.
+
+The database schema and the cron schedule are files the stack reads out of
+the repo at deploy time. Without this setting, Coolify deploys from a
+directory where those files don't exist and mounts empty folders in their
+place - the database never gets its tables and nothing works. With it,
+everything mounts from the checked-out repo, same as a manual install.
+
+</Step>
+
+<Step title="Deploy">
+
+Hit **Deploy**. Coolify pulls the prebuilt images (nothing is compiled on
+your server), generates the internal secrets - the Postgres password and the
+cron token are magic `SERVICE_PASSWORD_*` variables, created once and stable
+across every future redeploy - and the `migrate` one-shot installs the
+schema.
+
+There is nothing to fill in by hand: the **Environment Variables** tab lists
+optional overrides (`DASHBOARD_PASSWORD`, Search Console JSON, DataForSEO
+keys, ...), but every one of them is collected by the setup wizard in the
+browser, which stores them in the database. Leave them empty.
+
+When the deploy finishes, the `app` service has a generated URL under your
+Coolify wildcard domain - click it and the dashboard loads over HTTPS.
+
+</Step>
+
+<Step title="Put it on your own subdomain">
+
+The generated URL works, but you'll want a real address. Two small steps:
+
+1. In your DNS, add an **A record** for `dispatch.your-domain.com` pointing
+   at the Coolify server's IP (the same record shape as in
+   [the VPS guide](/docs/vps), which walks it click by click).
+2. In the resource's settings, change the `app` service's domain to
+   `https://dispatch.your-domain.com` and **redeploy**.
+
+Coolify's proxy fetches the certificate, and the redeploy is what tells
+DispatchSEO its own address (`APP_URL` follows the domain automatically) -
+so the links the wizard generates carry your real domain.
+
+</Step>
+
+<Step title="Walk the setup wizard">
+
+Open the dashboard, choose a password, and the setup wizard takes it from
+there - your site, Search Console, keyword data, publish mode, and your
+coding agent. Every screen is covered in
+[The setup wizard, step by step](/docs/setup-wizard).
+
+One note for the wizard's last screen, same as any server install: **the
+builder token is created on your own computer** (`claude setup-token` opens
+a browser login), then pasted on the dashboard's "Turn on automatic builds"
+step. Nothing goes into Coolify's env for that - the token is stored
+encrypted in your database and the in-stack builder picks it up.
+
+</Step>
+
+</Steps>
+
+<Callout type="warning" title="Where your data lives">
+Everything is in two named Docker volumes on the Coolify server -
+`dispatch-pgdata` is the database. They survive redeploys, restarts, and
+image upgrades, but Coolify's **Delete Resource** deletes the volumes with
+the stack. Before deleting or moving anything, take a backup:
+[Upgrading and backups](/docs/upgrading) has the one-line `pg_dump`.
+</Callout>
+
+## Upgrading
+
+Hit **Redeploy**. Coolify pulls the newer images and the current repo, and
+the `migrate` service re-applies the schema on boot - it's idempotent, so an
+upgrade is the same act as a deploy. Coolify's auto-update webhooks work
+too, if you'd rather track `main` automatically.

--- a/src/content/docs/vps.mdx
+++ b/src/content/docs/vps.mdx
@@ -4,7 +4,9 @@ description: One line installs everything - Docker included - and one .env line 
 ---
 
 Any provider works (Hetzner, DigitalOcean, Vultr, ...); a 1 GB Ubuntu or
-Debian box is enough. About five minutes end to end.
+Debian box is enough. About five minutes end to end. (Server already running
+[Coolify](/docs/coolify)? That guide deploys the same stack from its UI
+instead - no SSH.)
 
 <Steps>
 

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -73,6 +73,14 @@ export type ChangelogEntry = {
 // this list - it exists so that writing the note down doesn't ping anyone.
 export const UNRELEASED: { kind: ChangeKind; text: string }[] = [
   {
+    kind: "new",
+    text:
+      "Run Coolify on your server? DispatchSEO now deploys straight from its UI: point a " +
+      "resource at the repo's new docker/coolify/docker-compose.yml template and Coolify " +
+      "generates the secrets and puts the dashboard on your domain with HTTPS - no SSH, no " +
+      ".env file. The docs' new \"A Coolify server\" page walks it click by click.",
+  },
+  {
     kind: "improved",
     text:
       "GitHub stops emailing you \"Run failed\" for the SEO workflows. A failed run still " +

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -47,6 +47,7 @@ export const DOCS_NAV: { section: string; items: DocsNavItem[] }[] = [
     items: [
       { slug: "docker-compose", title: "Your own computer" },
       { slug: "vps", title: "A VPS or server" },
+      { slug: "coolify", title: "A Coolify server" },
       { slug: "local-development", title: "From source (contributors)" },
     ],
   },


### PR DESCRIPTION
## Summary

Takes the **Coolify** slice of #16 (one platform per PR). Adds a Coolify-specific compose template plus a step-by-step docs page, so someone already running Coolify can deploy the whole stack from its UI - generated secrets, their own domain with HTTPS, no SSH and no `.env`.

## Changes

- **`docker/coolify/docker-compose.yml`** - the template. Same six services as the root compose, reshaped for the platform, each deviation commented in the file:
  - No `caddy` and no published `ports:` - Coolify's proxy terminates TLS and routes the assigned domain to the app container via the `SERVICE_FQDN_APP_3000` magic variable. `APP_URL` uses the port-specific `SERVICE_URL_APP_3000` form because the generic variant does not follow UI domain changes (coollabsio/coolify#8912).
  - No `build:` - Coolify builds every service that carries one, and a Next.js build is heavier than many Coolify boxes; prebuilt GHCR images instead (forks restore `build:`).
  - Secrets (`CRON_SECRET`, Postgres password) are generated `SERVICE_PASSWORD_*` magic variables - stable across redeploys, nothing to fill in.
  - Bind mounts are written relative to the repo root (Coolify resolves against Base Directory) and require **Preserve Repository During Deployment**, without which Coolify mounts empty directories where `setup.sql` and the crontab should be (coollabsio/coolify#6056) - the docs make that a dedicated step.
  - App/builder env lists verified key-by-key against the root compose (the app enumerates env explicitly; a missing var never reaches the container - including the builder credentials the app must see to hand out jobs).
- **`src/content/docs/coolify.mdx`** - "Install on Coolify": create the resource, the preserve-repo setting, deploy, own subdomain, wizard. Persistence called out per the issue: data lives in the `dispatch-pgdata` / `dispatch-builder` named volumes, survives redeploys, and **Delete Resource deletes it** - backup link included.
- **`src/lib/docs.ts`** - nav entry "A Coolify server" under Installation (sitemap and llms.txt pick it up from there).
- **`src/content/docs/vps.mdx`**, **`docs/SELF_HOSTING.md`** - one-line cross-links.
- **`src/lib/changelog.ts`** - `UNRELEASED` line (staged only, no release cut).

MCP parity note per the repo convention: deploy template + docs only, no per-tenant state touched, so there is deliberately no MCP counterpart.

## Test plan

- [x] `pnpm build` green; `/docs/coolify` prerenders with content, nav renders.
- [x] Template parses (YAML + `docker compose config`; the only flag is `exclude_from_hc`, Coolify's own documented extension - the file header marks it Coolify-only).
- [x] Env parity app/builder vs root compose checked key-by-key.
- [ ] **Not yet deployed on a live Coolify instance.** The issue's bar is "say in the PR that you deployed it and it booted to the wizard" - I'm stating the opposite honestly: the template follows Coolify's current compose docs (magic variables, base-directory path resolution, preserve-repo behavior), but it needs one real deploy reaching the setup wizard before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for deploying DispatchSEO on Coolify with generated secrets, HTTPS, persistent storage, migrations, scheduled tasks, and builder services.
  * Added a dedicated Coolify installation guide covering setup, domains, backups, and upgrades.

* **Documentation**
  * Added Coolify to the installation navigation and self-hosting guidance.
  * Updated VPS requirements and documented Coolify as an alternative deployment option.

* **Changelog**
  * Added the Coolify deployment option to the unreleased changes list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->